### PR TITLE
Remove wraith from main.yml as it does not install cleanly

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,5 +3,4 @@
 - include: install_behat.yml
 - include: install_codeception.yml
 - include: install_phantomjs.yml
-- include: install_wraith.yml
 - include: install_phantomas.yml


### PR DESCRIPTION
I've left the wraith yml so it can be fixed, but in the meantime I've removed it from main.yml so it doesn't break provisioning of new servers.
